### PR TITLE
Add support for differing colour pickers, and disabling alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
+package-lock.json
 .npm

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ import ColorPicker from 'material-ui-color-picker'
 <ColorPicker
   name='color'
   defaultValue='#000'
+  disableAlpha={ false }
+  pickerType='Circle'
   onChange={color => console.log(color)}
 />
 ```
+
+`pickerType` can be any React Color supported class. `CirclePicker` becomes `Circle`. 
 
 There is not so much properties at this time. The was very quickly designed for my needs. Feel free to submit a PR with new features ;)
 

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -13,6 +13,8 @@ const ColorPicker = ({
   defaultValue,
   onChange,
   convert,
+  pickerType,
+  disableAlpha,
 
   // Text field
   name,
@@ -43,6 +45,8 @@ const ColorPicker = ({
     {showPicker && (
       <PickerDialog
         value={value}
+        pickerType={pickerType}
+        disableAlpha={disableAlpha}
         onClick={() => {
           setShowPicker(false)
           onChange(value)

--- a/src/components/PickerDialog.js
+++ b/src/components/PickerDialog.js
@@ -1,28 +1,37 @@
 
 import React, { PropTypes } from 'react'
-import { ChromePicker } from 'react-color'
+// import reactColor from 'react-color'
+let reactColor = require('react-color')
 
 const PickerDialog = ({
   value,
   onClick,
-  onChange
-}) => (
-  <div style={{ position: 'absolute', zIndex: '2' }}>
-    <div
-      style={{ position: 'fixed', top: '0px', right: '0px', bottom: '0px', left: '0px' }}
-      onClick={onClick}
-    />
-    <ChromePicker
-      color={value}
-      onChange={onChange}
-    />
-  </div>
-)
+  onChange,
+  pickerType,
+  disableAlpha
+}) => {
+  let PickerType = reactColor[(pickerType || 'Chrome') + 'Picker']
+  window.console.log((pickerType || 'Chrome') + 'Picker', reactColor, PickerType)
+  return (
+    <div style={{ position: 'fixed', zIndex: '2' }}>
+      <div
+        style={{ position: 'fixed', top: '0px', right: '0px', bottom: '0px', left: '0px' }}
+        onClick={onClick}
+      />
+      <PickerType
+        color={value}
+        disableAlpha={ disableAlpha || false}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
 
 PickerDialog.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  disableAlpha: PropTypes.bool
 }
 
 export default PickerDialog

--- a/stories/index.js
+++ b/stories/index.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { storiesOf, action } from '@kadira/storybook'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import Toolbar from 'material-ui/Toolbar'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 
 injectTapEventPlugin()
@@ -11,10 +12,25 @@ import ColorPicker from '../src'
 storiesOf('ColorPicker', module)
   .add('simple', () => (
     <MuiThemeProvider>
+    <Toolbar style={{ background: 'none' }}>
       <ColorPicker
         defaultValue='#000'
         onChange={action('changed')}
-        floatingLabelText='Color picker'
+        floatingLabelText='Color Picker'
       />
+      <ColorPicker
+        defaultValue='#000'
+        onChange={action('changed')}
+        disableAlpha={ true }
+        floatingLabelText='No Alpha'
+      />
+      <ColorPicker
+        defaultValue='#000'
+        onChange={action('changed')}
+        disableAlpha={ true }
+        pickerType='Circle'
+        floatingLabelText='Circle Picker'
+      />
+    </Toolbar>
     </MuiThemeProvider>
   ))


### PR DESCRIPTION
This PR adds support for using different colour pickers, as provided by React Color. It also allows you to use the disableAlpha property. 

For instance, you can now do:

```js
<ColorPicker
  name='color'
  defaultValue='#000'
  disableAlpha={ false }
  pickerType='Circle'
  onChange={color => console.log(color)}
/>
```