### PR TITLE
Readd type declaration location

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
   "peerDependencies": {
     "@material-ui/core": "^4.8.3",
     "react": "^16.12.0"
-  }
+  },
+  "types": "src/index.d.ts"
 }


### PR DESCRIPTION
It seems this got lost while upgrading to material-ui 4 (e8678c63480a62d631465bd94dfbcf45ee7d0d73)