### PR TITLE
Show color in text field in tsx

### DIFF
--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -33,6 +33,7 @@ const ColorPicker = ({
 }) => (
   <>
     <TextField
+      value={value}
       name={name}
       id={id}
       label={floatingLabelText || label}


### PR DESCRIPTION
Right now the only way to show color hex in text field is using InputProps:

```
<ColorPicker
                floatingLabelText="Font Color"
                name="font_color"
                id="font_color"
                value={currentLine.font_color || '#ffffff'}
                internalValue={currentLine.font_color || '#ffffff'}
                onChange={handleChangeFontColor}
                style={{ color: '#000000' }}
                InputProps={{ value: currentLine.font_color || '#ffffff' }}
 />
```